### PR TITLE
Rename jobs in GitHub workflows for clarity: 'build' to 'deploy' in d…

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -4,14 +4,10 @@ on:
   push: # Trigger the workflow on push to develop branch
     branches:
       - develop # should be the default branch in your repository
-      # Conditions:
-      # Require a pull request before merging
-      # Lock branch
-      # Require conversation resolution before merging
   workflow_dispatch: # Trigger the workflow manually
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
     - name: Deploy

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: # Trigger the workflow manually
 
 jobs:
-  build:
+  build_validate:
     runs-on: ubuntu-latest
     steps:
     - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release Branch Workflow
 on:
   pull_request: # Trigger the workflow on pull request to main branch
     branches:
-      - main
+      - main # Should use the rebase and merge strategy
   workflow_dispatch: # Trigger the workflow manually
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,25 +2,38 @@
 
 This repository contains a simple example of how to use the cherry-pick release strategy.
 
-## Create a new feature branch
+## Create a new feature branch and make changes
 
 ```bash
-git checkout -b DATA-1234-my-feature # develop should be the base branch
+git checkout -b DATA-1234-my-feature develop # develop should be the base branch
 ```
 
-## Trigger a build when a PR is created to the develop branch
-
+## Pull request the feature branch to the develop branch
 The workflows file `.github/workflows/feature.yaml` is triggered when a PR is created to the develop branch.
-Or the workflow can be triggered manually, to verify the deployment of your change on the cloud environment.
 
-## Merge the feature branch to the develop branch
+## Complete the feature pull request
+Once the PR is approved and merged, the feature branch can be deleted.
+Merge strategy: squash and merge.
+The workflow file `.github/workflows/develop.yaml` is triggered when the develop branch is updated and deploys the changes to the develop environment.
 
-The feature branch is merged to the develop branch using a PR.
-
-## Cherry-pick the develop branch to the release branch
-
+## Create a release branch and cherry-pick the develop branch
 ```bash
-git checkout -b release/1.0 # main should be the base branch
-git cherry-pick <commit-hash>
+git checkout -b release/1.0 main # main should be the base branch
+git cherry-pick 192274f23abf0aeaadab4bd6b1981c4bec1935f8 # a commit from the develop branch
+...
 ```
 
+## Pull request the release branch to the main branch
+The workflows file `.github/workflows/release.yaml` is triggered when a PR is created to the main branch.
+This releases the changes to the acceptance environment.
+The workflow file `.github/workflows/main.yaml` is triggered when the main branch is updated and deploys the changes to the production environment.
+Merge strategy: rebase and merge.
+
+## Update the develop branch with the main branch
+The develop branch should be updated with the changes from the main branch, so that released features are synchronized with the develop branch and un-released features are available for the next release.
+
+```bash
+git checkout develop
+git rebase --reapply-cherry-picks --strategy-option=ours main
+git push --force
+```


### PR DESCRIPTION
…evelop.yaml and 'build' to 'build_validate' in feature.yaml (#3)

Co-authored-by: Robert ter Luun <rterluun@ilionx.com>

Update release branch workflow to prevent squash and merge on pull requests to main

Update release branch workflow to enforce rebase and merge strategy for pull requests to main

Refactor develop.yaml workflow and update README for clarity on feature branch process

Update README to include merge strategy for pull requests to main